### PR TITLE
Create a short config by default, option for full.  Fixes #44

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ using rover options.
 | help / -h           | False                | Show the help message and exit |
 | version             | ==SUPPRESS==         | Show program's version number and exit |
 | full-help / -H      | False                | Show full help details         |
+| full-config         | False                | Initialize with full configuration file |
 | file / -f           | rover.config         | Specify configuration file     |
 | dev                 | False                | Development mode (show exceptions)? |
 | delete-files        | True                 | Delete temporary files?        |

--- a/rover/args.py
+++ b/rover/args.py
@@ -65,6 +65,7 @@ FORCEFAILURES = 'force-failures'
 FORCE_METADATA_RELOAD = 'force-metadata-reload'
 FORCEREQUEST = 'force-request'
 H, FULLHELP = 'H', 'full-help'
+FULLCONFIG = 'full-config'
 HTTPBINDADDRESS = 'http-bind-address'
 HTTPPORT = 'http-port'
 HTTPRETRIES = 'http-retries'
@@ -102,6 +103,10 @@ BIG_V, VERSION = 'V', 'version'
 
 LITTLE_HELP = (TIMESPANTOL, DOWNLOADRETRIES, LOGDIR, VERBOSITY, WEB, EMAIL,
                VERSION, HELP, FULLHELP, FILE, AVAILABILITYURL, DATASELECTURL)
+LITTLE_CONFIG = (DATADIR, DOWNLOADRETRIES, DOWNLOADWORKERS, OUTPUT_FORMAT,
+                 ASDF_FILENAME, STATIONURL, AVAILABILITYURL, DATASELECTURL,
+                 TEMPDIR, LOGDIR, LOGVERBOSITY, VERBOSITY, WEB, HTTPPORT,
+                 EMAIL, SMTPADDRESS, SMTPPORT)
 DYNAMIC_ARGS = (VERSION, HELP, FULLHELP)
 
 # default values (for non-boolean parameters)
@@ -263,6 +268,7 @@ class Arguments(ArgumentParser):
 
         self.add_argument(m(BIG_V), mm(VERSION), action='version', version='ROVER %s' % __version__)
         self.add_argument(m(H), mm(FULLHELP), action=FullHelpAction, help='show full help details')
+        self.add_argument(mm(FULLCONFIG), default=False, action='store_bool', help='initialize with full configuration file', metavar='')
 
         # operation details
         self.add_argument(m(F), mm(FILE), default=DEFAULT_FILE, help='specify configuration file')
@@ -420,8 +426,14 @@ class Arguments(ArgumentParser):
         If keywords are specified, they over-ride defaults and args.
         """
         create_parents(path)
+
+        if "WRITE_FULL_CONFIG" in kargs and not kargs["WRITE_FULL_CONFIG"]:
+            actions = [action for action in self._actions if unbar(action.dest) in LITTLE_CONFIG]
+        else:
+            actions = self._actions
+
         with open(path, 'w') as out:
-            for action in self._actions:
+            for action in actions:
                 name, default = action.dest, action.default
                 if unbar(name) not in DYNAMIC_ARGS:
                     if default is not None:

--- a/rover/config.py
+++ b/rover/config.py
@@ -5,8 +5,9 @@ from os import makedirs, getcwd
 from os.path import isabs, join, realpath, abspath, expanduser, dirname
 from re import compile, sub
 
-from .args import Arguments, LOGDIR, LOGSIZE, LOGCOUNT, LOGVERBOSITY, VERBOSITY, LOGUNIQUE, LOGUNIQUEEXPIRE, \
-    FILEVAR, DIRVAR, TEMPDIR, DATADIR, COMMAND, unbar, DYNAMIC_ARGS, INIT_REPOSITORY, m, F, FILE, ASDF_FILENAME
+from .args import Arguments, LOGDIR, LOGSIZE, LOGCOUNT, LOGVERBOSITY, \
+    VERBOSITY, LOGUNIQUE, LOGUNIQUEEXPIRE, FILEVAR, DIRVAR, TEMPDIR, DATADIR, \
+    COMMAND, unbar, DYNAMIC_ARGS, INIT_REPOSITORY, m, F, FILE, FULLCONFIG, ASDF_FILENAME
 from .logs import init_log, log_name
 from .sqlite import init_db
 from .utils import safe_unlink, canonify
@@ -242,7 +243,7 @@ will create the repository in ~/rover
     def __create(self):
         config_file = self.__config.file(FILE)
         self.__log.default('Writing new config file "%s"' % config_file)
-        Arguments().write_config(config_file, self.__args)
+        Arguments().write_config(config_file, self.__args, WRITE_FULL_CONFIG=self.__config.arg(FULLCONFIG))
         self.__config.dir(DATADIR)
         db = init_db(timeseries_db(self.__config), self.__log)
         db.execute('PRAGMA journal_mode=WAL')


### PR DESCRIPTION
By default when doing an `init-repository` command a short configuration that only contains the key parameters is written.  A new option of `--full-config` will force the writing of a full configuration file as was done previously.

When ROVER writes a configuration file for internal use, i.e. for a sub-rover process, it always writes a full config file.