### PR TITLE
Fix python 2 compatibility.  Fixes #82

### DIFF
--- a/rover/manager.py
+++ b/rover/manager.py
@@ -794,7 +794,7 @@ class DownloadManager(SqliteSupport):
                 if quiet:
                     complete = True
                 else:
-                    raise e
+                    raise
             if complete:
                 self._log.debug('Source %s complete' % self._source(name))
                 del self._sources[name]

--- a/rover/retrieve.py
+++ b/rover/retrieve.py
@@ -91,12 +91,12 @@ commands for more details.
     rover retrieve N_S_L_C.txt
 
 processes a file containing a request to download, ingest, and index
-data missing from rover’s local repository.
+data missing from ROVER's local repository.
 
     rover retrieve IU_ANMO_00_BH1 2017-01-01 2017-01-04
 
 processes a command line request to download, ingest, and index
-data missing from rover’s local repository.
+data missing from ROVER's local repository.
 
 """
 

--- a/rover/subscribe.py
+++ b/rover/subscribe.py
@@ -100,7 +100,7 @@ dates that are missing from the repository.
                 log_file_contents(path1, self._log, 10)
                 self._log.error('The first 10 lines of the existing subscription are:')
                 log_file_contents(row[0], self._log, 10)
-                raise e
+                raise
 
     def run(self, args):
         # input is a temp file as we prepend options


### PR DESCRIPTION
This fixes python 2 compatibility by replacing non-ASCII characters in some a doc block.  Also fixes truncated by tracebacks in python 2 by re-raising them with full context.