### PR TITLE
Support for fetching, building and installing mseedindex from pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class InstallBase():
     def compile_and_install_mseedindex(self, mseedindex_path):
         """Used the subprocess module to compile/install mseedindex."""
         # compile the software
-        cmd = "WITHOUTPOSTGRESQL=1 make"
+        cmd = "WITHOUTPOSTGRESQL=1 CFLAGS='-O2' make"
         subprocess.check_call(cmd, cwd=mseedindex_path, shell=True)
         
         venv = self.get_virtualenv_path()


### PR DESCRIPTION
If one runs:

`pip install rover --install-option="--mseedindex"`

or locally

`pip install . --install-option="--mseedindex"`
or (developer mode)
`pip install -e . --install-option="--mseedindex"`

then the setup.py module will try to automatically download and install mseedindex before installing ROVER into the active python environment.