### PR TITLE
Update documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ ROVER is a command line tool to robustly retrieve geophysical timeseries data fr
 
 ## Installation <a id="installation"></a>
 
-ROVER is a command-line tool dependent on Python 2.7, 3.5 or a newer version. Python 3.7 or above is preferred. Pre-installed versions of Python available on some operating systems, such as macOS, may not support ROVER installation or operation. We suggest installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) 3 (or [Anaconda](https://www.anaconda.com/distribution/#download-section) if you wish) for the best results.
+ROVER is a command-line tool dependent on Python 2.7, 3.6.2 or a newer version. Python 3.7 or above running on Linux or MacOSX is preferred (pre-installed versions of Python available on some operating systems, such as MacOS, may not support ROVER installation or operation). We suggest installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) 3 (or [Anaconda](https://www.anaconda.com/distribution/#download-section) if you wish) for the best results.
 
 ### Option 1
 

--- a/rover/manager.py
+++ b/rover/manager.py
@@ -752,12 +752,11 @@ class DownloadManager(SqliteSupport):
                     sncl_seconds += seconds
                     source_seconds += seconds
                     total_seconds += seconds
-                if sncl_seconds:
-                    source_sncls += 1
-                    total_sncls += 1
-                    print('  %s  (%4.2f sec)' % (coverage.sncl, sncl_seconds))
-                    for (start, end) in coverage.timespans:
-                        print('    %s - %s  (%4.2f sec)' % (format_epoch(start), format_epoch(end), end - start))
+                source_sncls += 1
+                total_sncls += 1
+                print('  %s  (%4.2f sec)' % (coverage.sncl, sncl_seconds))
+                for (start, end) in coverage.timespans:
+                    print('    %s - %s  (%4.2f sec)' % (format_epoch(start), format_epoch(end), end - start))
             if name != DEFAULT_NAME:
                 if source_sncls:
                     print()


### PR DESCRIPTION
Update index.docs to inform users that ROVER does not work with Python 3.6.1. Also, that Linux and MacOSX are ROVER's preferred operating systems. 