### PR TITLE
Increase sql busy timeout and add commit statements to prevent DB locking

### DIFF
--- a/rover/manager.py
+++ b/rover/manager.py
@@ -891,6 +891,7 @@ class DownloadManager(SqliteSupport):
         with self._db:  # single transaction
             self._db.cursor().execute('BEGIN')
             self._db.execute('DELETE FROM rover_download_stats', tuple())
+            self._db.commit()
             for source in self._sources.values():
                 progress = source.stats()
                 self._db.execute('''INSERT INTO rover_download_stats

--- a/rover/process.py
+++ b/rover/process.py
@@ -59,6 +59,7 @@ class ProcessManager(SqliteSupport):
             else:
                 self._log.debug('Removing dead process %s/%d' % (candidate, pid))
                 self._db.execute('DELETE FROM rover_processes WHERE pid = ?', (pid,))
+                self._db.commit()
         except StopIteration:
             pass  # table is empty
         try:

--- a/rover/sqlite.py
+++ b/rover/sqlite.py
@@ -15,7 +15,8 @@ def init_db(dbpath, log):
     """
 
     log.debug('Connecting to sqlite3 %s' % dbpath)
-    db = connect(dbpath, timeout=60.0)
+    # Timeout is in seconds
+    db = connect(dbpath, timeout=120.0)
     # https://www.sqlite.org/foreignkeys.html
     db.execute('PRAGMA foreign_keys = ON')
     db.execute('PRAGMA case_sensitive_like = ON')  # as used by mseedindex


### PR DESCRIPTION
It seems like this database locking is associated with multiple open transactions that are all trying to write or read from the database at the same time. The busy timeout has been increased to 120 seconds by changing line 19 in sqlite.py. The busy timeout allows incoming SQL transactions to sleep while another transaction is interfacing with ### the database, the maximum amount of time that the transaction can sleep is set in seconds by the integer value above Busy Timeout.

A connection.commit() command also has been added after the `DELETE FROM` statements. Committing the `DELETE FROM` statements to the database should allow the database to unlock and be ready for another transaction commit .

The request.txt, available in issue #113 , has been run through an instance of modified ROVER with no locking database exceptions.